### PR TITLE
Implement get payment intent list of Point API

### DIFF
--- a/src/main/java/com/mercadopago/client/point/PointClient.java
+++ b/src/main/java/com/mercadopago/client/point/PointClient.java
@@ -13,6 +13,7 @@ import com.mercadopago.net.MPHttpClient;
 import com.mercadopago.net.MPRequest;
 import com.mercadopago.net.MPResponse;
 import com.mercadopago.resources.point.PointPaymentIntent;
+import com.mercadopago.resources.point.PointPaymentIntentList;
 import com.mercadopago.serialization.Serializer;
 import java.util.logging.Logger;
 import java.util.logging.StreamHandler;
@@ -23,6 +24,9 @@ public class PointClient extends MercadoPagoClient {
 
   private static final String PAYMENT_INTENT_URL =
       "/point/integration-api/devices/%s/payment-intents";
+
+  private static final String PAYMENT_INTENT_LIST_URL =
+      "/point/integration-api/payment-intents/events";
 
   /** Default constructor. Uses the default http client used by the SDK. */
   public PointClient() {
@@ -85,6 +89,53 @@ public class PointClient extends MercadoPagoClient {
     MPResponse response = send(mpRequest, requestOptions);
     PointPaymentIntent result =
         deserializeFromJson(PointPaymentIntent.class, response.getContent());
+    result.setResponse(response);
+
+    return result;
+  }
+
+  /**
+   * Method responsible for getting a list of payment intents with their final states between a date
+   * range.
+   *
+   * @param request attributes used to set date range.
+   * @return list of payment intents.
+   * @throws MPException an error if the request fails
+   * @see <a
+   *     href="https://www.mercadopago.com.br/developers/pt/reference/integrations_api/_point_integration-api_payment-intents_events/get">api
+   *     docs</a>
+   */
+  public PointPaymentIntentList getPaymentIntentList(PointPaymentIntentListRequest request)
+      throws MPException, MPApiException {
+    return this.getPaymentIntentList(request, null);
+  }
+
+  /**
+   * Method responsible for getting a list of payment intents with their final states between a date
+   * range with request options.
+   *
+   * @param request attributes used to set date range.
+   * @param requestOptions metadata to customize the request
+   * @return list of payment intents.
+   * @throws MPException an error if the request fails
+   * @see <a
+   *     href="https://www.mercadopago.com.br/developers/pt/reference/integrations_api/_point_integration-api_payment-intents_events/get">api
+   *     docs</a>
+   */
+  public PointPaymentIntentList getPaymentIntentList(
+      PointPaymentIntentListRequest request, MPRequestOptions requestOptions)
+      throws MPException, MPApiException {
+
+    MPRequest mpRequest =
+        MPRequest.builder()
+            .uri(PAYMENT_INTENT_LIST_URL)
+            .method(HttpMethod.GET)
+            .queryParams(request.getParams())
+            .build();
+
+    MPResponse response = send(mpRequest, requestOptions);
+    PointPaymentIntentList result =
+        deserializeFromJson(PointPaymentIntentList.class, response.getContent());
     result.setResponse(response);
 
     return result;

--- a/src/main/java/com/mercadopago/client/point/PointClient.java
+++ b/src/main/java/com/mercadopago/client/point/PointClient.java
@@ -125,6 +125,7 @@ public class PointClient extends MercadoPagoClient {
   public PointPaymentIntentList getPaymentIntentList(
       PointPaymentIntentListRequest request, MPRequestOptions requestOptions)
       throws MPException, MPApiException {
+    LOGGER.info("Sending get point payment intent list request");
 
     MPRequest mpRequest =
         MPRequest.builder()

--- a/src/main/java/com/mercadopago/client/point/PointClient.java
+++ b/src/main/java/com/mercadopago/client/point/PointClient.java
@@ -102,7 +102,7 @@ public class PointClient extends MercadoPagoClient {
    * @return list of payment intents.
    * @throws MPException an error if the request fails
    * @see <a
-   *     href="https://www.mercadopago.com.br/developers/pt/reference/integrations_api/_point_integration-api_payment-intents_events/get">api
+   *     href="https://www.mercadopago.com/developers/en/reference/integrations_api/_point_integration-api_payment-intents_events/get">api
    *     docs</a>
    */
   public PointPaymentIntentList getPaymentIntentList(PointPaymentIntentListRequest request)
@@ -119,7 +119,7 @@ public class PointClient extends MercadoPagoClient {
    * @return list of payment intents.
    * @throws MPException an error if the request fails
    * @see <a
-   *     href="https://www.mercadopago.com.br/developers/pt/reference/integrations_api/_point_integration-api_payment-intents_events/get">api
+   *     href="https://www.mercadopago.com/developers/en/reference/integrations_api/_point_integration-api_payment-intents_events/get">api
    *     docs</a>
    */
   public PointPaymentIntentList getPaymentIntentList(

--- a/src/main/java/com/mercadopago/client/point/PointPaymentIntentListRequest.java
+++ b/src/main/java/com/mercadopago/client/point/PointPaymentIntentListRequest.java
@@ -10,7 +10,10 @@ import lombok.Getter;
 @Getter
 @Builder
 public class PointPaymentIntentListRequest {
+  /** Initial date. */
   private final LocalDate startDate;
+
+  /** End date. */
   private final LocalDate endDate;
 
   /**

--- a/src/main/java/com/mercadopago/client/point/PointPaymentIntentListRequest.java
+++ b/src/main/java/com/mercadopago/client/point/PointPaymentIntentListRequest.java
@@ -1,0 +1,27 @@
+package com.mercadopago.client.point;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+/** Responsible for setting date range for getting payment intent list. */
+@Getter
+@Builder
+public class PointPaymentIntentListRequest {
+  private final LocalDate startDate;
+  private final LocalDate endDate;
+
+  /**
+   * Method responsible for mapping data range.
+   *
+   * @return map with data range.
+   */
+  public Map<String, Object> getParams() {
+    Map<String, Object> params = new HashMap<>();
+    params.put("startDate", this.startDate);
+    params.put("endDate", this.endDate);
+    return params;
+  }
+}

--- a/src/main/java/com/mercadopago/resources/point/PointPaymentIntentList.java
+++ b/src/main/java/com/mercadopago/resources/point/PointPaymentIntentList.java
@@ -1,0 +1,12 @@
+package com.mercadopago.resources.point;
+
+import com.mercadopago.net.MPResource;
+import java.util.List;
+import lombok.Getter;
+
+/** PointPaymentIntentList class. */
+@Getter
+public class PointPaymentIntentList extends MPResource {
+  /** List of events. */
+  private List<PointPaymentIntentListEvent> events;
+}

--- a/src/main/java/com/mercadopago/resources/point/PointPaymentIntentListEvent.java
+++ b/src/main/java/com/mercadopago/resources/point/PointPaymentIntentListEvent.java
@@ -1,0 +1,17 @@
+package com.mercadopago.resources.point;
+
+import java.time.OffsetDateTime;
+import lombok.Getter;
+
+/** PointPaymentIntentListEvent class. */
+@Getter
+public class PointPaymentIntentListEvent {
+  /** Payment intent ID. */
+  private String paymentIntentId;
+
+  /** Payment status. */
+  private String status;
+
+  /** Payment creation date. */
+  private OffsetDateTime createdOn;
+}

--- a/src/main/java/com/mercadopago/serialization/Serializer.java
+++ b/src/main/java/com/mercadopago/serialization/Serializer.java
@@ -31,7 +31,7 @@ import java.util.List;
 public class Serializer {
 
   private static final String DESERIALIZE_DATE_FORMAT_ISO8601 =
-      "yyyy-MM-dd'T'HH:mm:ss.SSS[XXX][XX][X]";
+      "yyyy-MM-dd'T'HH:mm:ss[.SSS][XXX][XX][X]";
 
   private static final String SERIALIZE_DATE_FORMAT_ISO8601 = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
 

--- a/src/test/java/com/mercadopago/client/point/PointClientIT.java
+++ b/src/test/java/com/mercadopago/client/point/PointClientIT.java
@@ -1,6 +1,7 @@
 package com.mercadopago.client.point;
 
 import static com.mercadopago.net.HttpStatus.CREATED;
+import static com.mercadopago.net.HttpStatus.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -10,7 +11,9 @@ import com.mercadopago.BaseClientIT;
 import com.mercadopago.exceptions.MPApiException;
 import com.mercadopago.exceptions.MPException;
 import com.mercadopago.resources.point.PointPaymentIntent;
+import com.mercadopago.resources.point.PointPaymentIntentList;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 
 /** PointClientIT class. */
@@ -54,6 +57,38 @@ class PointClientIT extends BaseClientIT {
     }
   }
 
+  @Test
+  void getPaymentIntentListSuccess() {
+    try {
+      PointPaymentIntentList paymentIntentList =
+          client.getPaymentIntentList(newPaymentIntentListRequest());
+
+      assertNotNull(paymentIntentList.getResponse());
+      assertEquals(OK, paymentIntentList.getResponse().getStatusCode());
+      assertNotNull(paymentIntentList.getEvents());
+    } catch (MPApiException mpApiException) {
+      fail(mpApiException.getApiResponse().getContent());
+    } catch (MPException mpException) {
+      fail(mpException.getMessage());
+    }
+  }
+
+  @Test
+  void getPaymentIntentListWithRequestOptionsSuccess() {
+    try {
+      PointPaymentIntentList paymentIntentList =
+          client.getPaymentIntentList(newPaymentIntentListRequest(), buildRequestOptions());
+
+      assertNotNull(paymentIntentList.getResponse());
+      assertEquals(OK, paymentIntentList.getResponse().getStatusCode());
+      assertNotNull(paymentIntentList.getEvents());
+    } catch (MPApiException mpApiException) {
+      fail(mpApiException.getApiResponse().getContent());
+    } catch (MPException mpException) {
+      fail(mpException.getMessage());
+    }
+  }
+
   private void assertPaymentIntentFields(PointPaymentIntent paymentIntent) {
     assertNotNull(paymentIntent.getId());
     assertNotNull(paymentIntent.getAdditionalInfo());
@@ -88,5 +123,11 @@ class PointClientIT extends BaseClientIT {
         .payment(payment)
         .additionalInfo(additionalInfo)
         .build();
+  }
+
+  private PointPaymentIntentListRequest newPaymentIntentListRequest() {
+    LocalDate startDate = LocalDate.of(2022, 1, 1);
+    LocalDate endDate = LocalDate.of(2022, 1, 30);
+    return PointPaymentIntentListRequest.builder().startDate(startDate).endDate(endDate).build();
   }
 }

--- a/src/test/java/com/mercadopago/resources/mocks/response/point/payment_intent_list.json
+++ b/src/test/java/com/mercadopago/resources/mocks/response/point/payment_intent_list.json
@@ -1,0 +1,19 @@
+{
+  "events": [
+    {
+      "payment_intent_id": "d2ee3a75-ca25-4bf3-9eca-f5f2d8f23bf4",
+      "status": "ABANDONED",
+      "created_on": "2022-01-24T10:10:10Z"
+    },
+    {
+      "payment_intent_id": "a16aba35-d43c-409d-b6c8-c3020797b061",
+      "status": "CANCELED",
+      "created_on": "2022-01-25T10:10:10Z"
+    },
+    {
+      "payment_intent_id": "68bf6839-ddb3-4825-8f4c-7eb26e68a5c3",
+      "status": "ABANDONED",
+      "created_on": "2022-01-26T10:10:10Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Cambios realizados para el feature:
 * Implement point get payment intent list ([reference api](https://www.mercadopago.com.br/developers/en/reference/integrations_api/_point_integration-api_payment-intents_events/get))
 * Made nanoseconds of date optional on deserialization.

## Checklist validación PR:

- [X] Título y descripción clara del PR
- [X] Tests de mi funcionalidad 
- [X] Documentación de mi funcionalidad
- [X] Tests ejecutados y pasados
- [X] Branch Coverage >= 80%
