### PR TITLE
Fix/update libs with vulnerabilities

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  # Websec hook is MANDATORY, DO NOT comment it.
+  - repo: https://github.com/mercadolibre/fury_websec-git-hooks
+    rev: v1.0.3
+    hooks:
+      - id: pre_commit_hook
+        stages: [commit]
+      - id: post_commit_hook
+        stages: [post-commit]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ First time using Mercado Pago? Create your [Mercado Pago account](https://www.me
         <dependency>
             <groupId> com.mercadopago </groupId>
             <artifactId> sdk-java </artifactId>
-            <version> 1.11.5 </version>
+            <version> 1.11.6 </version>
         </dependency>
     </dependencies>
     ...

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.2.0</version>
+            <version>3.3.2</version>
         </dependency>
 
         <dependency>
@@ -222,7 +222,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.8</version>
+            <version>2.8.9</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.mercadopago</groupId>
     <artifactId>sdk-java</artifactId>
-    <version>1.11.5</version>
+    <version>1.11.6</version>
     <packaging>jar</packaging>
 
     <name>Mercadopago SDK</name>


### PR DESCRIPTION
## Cambios realizados para el feature:
 Update version lib gson 2.8.8 to 2.8.9 without vulnerability
 Update version lib maven-javadoc-plugin 3.3.2 without vulnerability
 Add file pre-commit-config.yml to check for vulnerabilities