### PR TITLE
Update javadoc plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,20 @@ maven-central-deploy.log
 .settings
 .project
 classes/
+
+### Gradle ###
+.gradle
+gradle/
+build.gradle
+settings.gradle
+gradlew
+gradlew.bat
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Cache of project
+.gradletasknamecache
+
+### Gradle Patch ###
+# Java heap dump
+*.hprof

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ already.
 <dependency>
     <groupId>com.mercadopago</groupId>
     <artifactId>sdk-java</artifactId>
-    <version>2.1.7</version>
+    <version>2.1.8</version>
 </dependency>
   ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ already.
 <dependency>
     <groupId>com.mercadopago</groupId>
     <artifactId>sdk-java</artifactId>
-    <version>2.1.8</version>
+    <version>2.1.9</version>
 </dependency>
   ```
 

--- a/build-gradle.sh
+++ b/build-gradle.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+VERSION="7.6.1"
+BREW_VERSION=${VERSION:0:1}
+INSTALL_DIR=gradle
+CMD=$(which gradle)
+
+check_gradle_installed() {
+  echo "Checking if gradle is installed globally..."
+  which gradle > /dev/null 2>&1
+  return $?
+}
+
+install() {
+  which brew > /dev/null 2>&1
+  if [ $? -eq 0 ];
+  then
+    echo "Homebrew detected. Install gradle globally?"
+    echo "[yes/no] default: yes"
+    read brew
+    if [[ "$brew" == "yes" ]] || [[ "$brew" == "" ]];
+    then
+      echo "brew"
+      install_brew
+    else
+      echo "local"
+      install_locally
+    fi
+  else
+    install_locally
+  fi
+}
+
+install_brew() {
+  echo "Installing version $BREW_VERSION globally with Homebrew..."
+  brew install "gradle@$BREW_VERSION"
+  ln -s /usr/local/opt/gradle@$BREW_VERSION/bin/gradle /usr/local/bin/gradle
+  CMD=$(which gradle)
+}
+
+install_locally() {
+  echo "Installing version $VERSION locally @ ./$INSTALL_DIR/..."
+  ls gradle > /dev/null 2>&1
+  if [ $? -gt 0 ];
+  then
+    mkdir gradle
+  fi
+  curl "https://downloads.gradle-dn.com/distributions/gradle-$VERSION-bin.zip" > "gradle/gradle-$VERSION-bin.zip"
+  unzip -d gradle "gradle/gradle-$GRADLE_VERSION-bin.zip"
+
+  export GRADLE_HOME="gradle/gradle-$VERSION"
+
+  CMD="$GRADLE_HOME/bin/gradle"
+}
+
+init() {
+  ls settings.gradle > /dev/null 2>&1
+
+  if [ $? -gt 0 ];
+  then
+    echo "Setting up project..."
+    $CMD init <<< "\r\rno\r"
+  fi
+}
+
+build() {
+  which gradle > /dev/null 2>&1
+
+  if [ $? -gt 0 ];
+  then
+    export GRADLE_HOME="gradle/gradle-$VERSION"
+    CMD="$GRADLE_HOME/bin/gradle"
+  fi
+
+  $CMD build
+}
+
+check_gradle_installed
+
+installed=$?
+if [ $installed -gt 0 ] ;
+then 
+  echo "Gradle not found. Installing..."
+  install
+fi
+
+init
+build

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.5.0</version>
                 <configuration>
                     <source>1.8</source>
                     <doclint>none</doclint>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.mercadopago</groupId>
     <artifactId>sdk-java</artifactId>
-    <version>2.1.9-1-SNAPSHOT</version>
+    <version>2.1.9</version>
     <packaging>jar</packaging>
 
     <name>Mercadopago SDK</name>

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,19 @@
         </snapshotRepository>
     </distributionManagement>
 
+    <repositories>
+        <repository>
+            <id>oss.sonatype.org-snapshot</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.mercadopago</groupId>
     <artifactId>sdk-java</artifactId>
-    <version>2.1.8</version>
+    <version>2.1.9-1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Mercadopago SDK</name>
@@ -224,7 +224,7 @@
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.3.2</version>
+            <version>3.5.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.mercadopago</groupId>
     <artifactId>sdk-java</artifactId>
-    <version>2.1.7</version>
+    <version>2.1.8</version>
     <packaging>jar</packaging>
 
     <name>Mercadopago SDK</name>

--- a/src/main/java/com/mercadopago/MercadoPagoConfig.java
+++ b/src/main/java/com/mercadopago/MercadoPagoConfig.java
@@ -15,7 +15,7 @@ import org.apache.http.client.HttpRequestRetryHandler;
 /** Mercado Pago configuration class. */
 public class MercadoPagoConfig {
 
-  public static final String CURRENT_VERSION = "2.1.9-1-SNAPSHOT";
+  public static final String CURRENT_VERSION = "2.1.9";
 
   public static final String PRODUCT_ID = "BC32A7VTRPP001U8NHJ0";
 

--- a/src/main/java/com/mercadopago/MercadoPagoConfig.java
+++ b/src/main/java/com/mercadopago/MercadoPagoConfig.java
@@ -15,7 +15,7 @@ import org.apache.http.client.HttpRequestRetryHandler;
 /** Mercado Pago configuration class. */
 public class MercadoPagoConfig {
 
-  public static final String CURRENT_VERSION = "2.1.7";
+  public static final String CURRENT_VERSION = "2.1.8";
 
   public static final String PRODUCT_ID = "BC32A7VTRPP001U8NHJ0";
 

--- a/src/main/java/com/mercadopago/MercadoPagoConfig.java
+++ b/src/main/java/com/mercadopago/MercadoPagoConfig.java
@@ -15,7 +15,7 @@ import org.apache.http.client.HttpRequestRetryHandler;
 /** Mercado Pago configuration class. */
 public class MercadoPagoConfig {
 
-  public static final String CURRENT_VERSION = "2.1.8";
+  public static final String CURRENT_VERSION = "2.1.9-1-SNAPSHOT";
 
   public static final String PRODUCT_ID = "BC32A7VTRPP001U8NHJ0";
 


### PR DESCRIPTION
this branch: 
- updates maven-javadoc-plugin to 3.5.0 due to errors when trying to add SDK as dependency in a gradle project
- adds script to build with gradle to test new dependencies
