### PR TITLE
checks if the x-idempotency-key was submitted by the user

### DIFF
--- a/src/main/java/com/mercadopago/client/MercadoPagoClient.java
+++ b/src/main/java/com/mercadopago/client/MercadoPagoClient.java
@@ -282,7 +282,7 @@ public abstract class MercadoPagoClient {
   }
 
   private boolean shouldAddIdempotencyKey(MPRequest request, Map headers) {
-    boolean containsIdempotency = headers.containsKey(Headers.IDEMPOTENCY_KEY);
+    boolean containsIdempotency = headers.containsKey(Headers.IDEMPOTENCY_KEY.toLowerCase());
 
     if (containsIdempotency) return false;
 

--- a/src/main/java/com/mercadopago/net/Headers.java
+++ b/src/main/java/com/mercadopago/net/Headers.java
@@ -2,23 +2,23 @@ package com.mercadopago.net;
 
 /** Headers class. */
 public class Headers {
-  public static final String AUTHORIZATION = "authorization";
+  public static final String AUTHORIZATION = "Authorization";
 
-  public static final String CONTENT_TYPE = "content-type";
+  public static final String CONTENT_TYPE = "Content-Type";
 
-  public static final String ACCEPT = "accept";
+  public static final String ACCEPT = "Accept";
 
-  public static final String USER_AGENT = "user-agent";
+  public static final String USER_AGENT = "User-Agent";
 
-  public static final String IDEMPOTENCY_KEY = "x-idempotency-key";
+  public static final String IDEMPOTENCY_KEY = "X-Idempotency-Key";
 
-  public static final String PRODUCT_ID = "x-product-id";
+  public static final String PRODUCT_ID = "X-Product-Id";
 
-  public static final String TRACKING_ID = "x-tracking-id";
+  public static final String TRACKING_ID = "X-Tracking-Id";
 
-  public static final String CORPORATION_ID = "x-corporation-id";
+  public static final String CORPORATION_ID = "X-Corporation-Id";
 
-  public static final String INTEGRATOR_ID = "x-integrator-id";
+  public static final String INTEGRATOR_ID = "X-Integrator-Id";
 
-  public static final String PLATFORM_ID = "x-platform-id";
+  public static final String PLATFORM_ID = "X-Platform-Id";
 }

--- a/src/main/java/com/mercadopago/net/Headers.java
+++ b/src/main/java/com/mercadopago/net/Headers.java
@@ -2,23 +2,23 @@ package com.mercadopago.net;
 
 /** Headers class. */
 public class Headers {
-  public static final String AUTHORIZATION = "Authorization";
+  public static final String AUTHORIZATION = "authorization";
 
-  public static final String CONTENT_TYPE = "Content-Type";
+  public static final String CONTENT_TYPE = "content-type";
 
-  public static final String ACCEPT = "Accept";
+  public static final String ACCEPT = "accept";
 
-  public static final String USER_AGENT = "User-Agent";
+  public static final String USER_AGENT = "user-agent";
 
-  public static final String IDEMPOTENCY_KEY = "X-Idempotency-Key";
+  public static final String IDEMPOTENCY_KEY = "x-idempotency-key";
 
-  public static final String PRODUCT_ID = "X-Product-Id";
+  public static final String PRODUCT_ID = "x-product-id";
 
-  public static final String TRACKING_ID = "X-Tracking-Id";
+  public static final String TRACKING_ID = "x-tracking-id";
 
-  public static final String CORPORATION_ID = "X-Corporation-Id";
+  public static final String CORPORATION_ID = "x-corporation-id";
 
-  public static final String INTEGRATOR_ID = "X-Integrator-Id";
+  public static final String INTEGRATOR_ID = "x-integrator-id";
 
-  public static final String PLATFORM_ID = "X-Platform-Id";
+  public static final String PLATFORM_ID = "x-platform-id";
 }

--- a/src/test/java/com/mercadopago/client/payment/PaymentClientIT.java
+++ b/src/test/java/com/mercadopago/client/payment/PaymentClientIT.java
@@ -60,7 +60,7 @@ public class PaymentClientIT extends BaseClientIT {
   @Test
   public void createPaymentWithCustomizedHeadersWithSuccess() {
     try {
-      PaymentCreateRequest paymentCreateRequest = pixPaymentRequest();
+      PaymentCreateRequest paymentCreateRequest = newPayment("approved");
 
       String idempotencyKey = UUID.randomUUID().toString();
       Map<String, String> customHeaders = new HashMap<>();
@@ -490,7 +490,7 @@ public class PaymentClientIT extends BaseClientIT {
     PaymentMethodRequest paymentMethod = PaymentMethodRequest.builder().data(data).build();
 
     PaymentPointOfInteractionRequest pointOfInteraction =
-        PaymentPointOfInteractionRequest.builder().type("TYPE").build();
+        PaymentPointOfInteractionRequest.builder().type("OPENPLATFORM").build();
 
     return PaymentCreateRequest.builder()
         .transactionAmount(new BigDecimal("100"))
@@ -504,25 +504,5 @@ public class PaymentClientIT extends BaseClientIT {
         .pointOfInteraction(pointOfInteraction)
         .paymentMethod(paymentMethod)
         .build();
-  }
-
-  public PaymentCreateRequest pixPaymentRequest() {
-
-    return PaymentCreateRequest.builder()
-        .transactionAmount(new BigDecimal(5))
-        .description("description")
-        .paymentMethodId("pix")
-        .payer(
-            PaymentPayerRequest.builder()
-                .email("test_user_45843885@testuser.com")
-                .firstName("User")
-                .lastName("Test")
-                .identification(
-                    IdentificationRequest.builder()
-                        .type("CPF")
-                        .number("01234567890").build())
-                .build())
-        .build();
-
   }
 }

--- a/src/test/java/com/mercadopago/client/payment/PaymentClientIT.java
+++ b/src/test/java/com/mercadopago/client/payment/PaymentClientIT.java
@@ -60,7 +60,7 @@ public class PaymentClientIT extends BaseClientIT {
   @Test
   public void createPaymentWithCustomizedHeadersWithSuccess() {
     try {
-      PaymentCreateRequest paymentCreateRequest = mockPaymentRequest();
+      PaymentCreateRequest paymentCreateRequest = pixPaymentRequest();
 
       String idempotencyKey = UUID.randomUUID().toString();
       Map<String, String> customHeaders = new HashMap<>();
@@ -506,7 +506,7 @@ public class PaymentClientIT extends BaseClientIT {
         .build();
   }
 
-  public PaymentCreateRequest mockPaymentRequest() {
+  public PaymentCreateRequest pixPaymentRequest() {
 
     return PaymentCreateRequest.builder()
         .transactionAmount(new BigDecimal(5))

--- a/src/test/java/com/mercadopago/helper/MockHelper.java
+++ b/src/test/java/com/mercadopago/helper/MockHelper.java
@@ -9,6 +9,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.mercadopago.MercadoPagoConfig;
 import com.mercadopago.exceptions.MPException;
+import com.mercadopago.net.Headers;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -118,17 +119,17 @@ public class MockHelper {
 
   private static boolean hasMandatoryHeaders(Header[] headers, String method) {
     List<String> mandatoryHeaders = new ArrayList<>();
-    mandatoryHeaders.add("Authorization");
-    mandatoryHeaders.add("User-Agent");
-    mandatoryHeaders.add("X-Product-Id");
-    mandatoryHeaders.add("X-Tracking-Id");
+    mandatoryHeaders.add(Headers.AUTHORIZATION);
+    mandatoryHeaders.add(Headers.USER_AGENT);
+    mandatoryHeaders.add(Headers.PRODUCT_ID);
+    mandatoryHeaders.add(Headers.TRACKING_ID);
 
     if ("POST".equals(method) || "PUT".equals(method)) {
-      mandatoryHeaders.add("Content-Type");
+      mandatoryHeaders.add(Headers.CONTENT_TYPE);
     }
 
     if ("POST".equals(method)) {
-      mandatoryHeaders.add("X-Idempotency-Key");
+      mandatoryHeaders.add(Headers.IDEMPOTENCY_KEY);
     }
 
     for (String mandatoryHeader : mandatoryHeaders) {
@@ -142,27 +143,27 @@ public class MockHelper {
 
   private static boolean haveMandatoryHeadersCorrectValues(Header[] headers) {
     for (Header header : headers) {
-      if ("Authorization".equals(header.getName()) && !header.getValue().startsWith("Bearer")) {
+      if (Headers.AUTHORIZATION.equals(header.getName()) && !header.getValue().startsWith("Bearer")) {
         return false;
       }
 
-      if ("User-Agent".equals(header.getName())
+      if (Headers.USER_AGENT.equals(header.getName())
           && !String.format("MercadoPago Java SDK/%s", MercadoPagoConfig.CURRENT_VERSION)
               .equals(header.getValue())) {
         return false;
       }
 
-      if ("X-Product-Id".equals(header.getName())
+      if (Headers.PRODUCT_ID.equals(header.getName())
           && !MercadoPagoConfig.PRODUCT_ID.equals(header.getValue())) {
         return false;
       }
 
-      if ("X-Tracking-Id".equals(header.getName())
+      if (Headers.TRACKING_ID.equals(header.getName())
           && !MercadoPagoConfig.TRACKING_ID.equals(header.getValue())) {
         return false;
       }
 
-      if ("Content-Type".equals(header.getName())
+      if (Headers.CONTENT_TYPE.equals(header.getName())
           && !"application/json; charset=UTF-8".equals(header.getValue())) {
         return false;
       }


### PR DESCRIPTION
## Cambios realizados para el feature:
 * shouldAddIdempotencyKey verifica se o integrador enviou o header x-idempotency-key, e se sim, não cria um novo x-idempotency-key.
 * Faz parte da task de [adicionar header "x-idempotency-key" nas requisições de criação de Payments](https://mercadolibre.atlassian.net/browse/CORECH2-1328)

## Checklist validación PR:

- [ ] Título y descripción clara del PR
- [ ] Tests de mi funcionalidad 
- [ ] Documentación de mi funcionalidad
- [ ] Tests ejecutados y pasados
- [ ] Branch Coverage >= 80%
