### PR TITLE
Add transaction id

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ already.
 <dependency>
     <groupId>com.mercadopago</groupId>
     <artifactId>sdk-java</artifactId>
-    <version>2.1.16</version>
+    <version>2.1.17</version>
 </dependency>
   ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.mercadopago</groupId>
     <artifactId>sdk-java</artifactId>
-    <version>2.1.16</version>
+    <version>2.1.17</version>
     <packaging>jar</packaging>
 
     <name>Mercadopago SDK</name>

--- a/src/main/java/com/mercadopago/MercadoPagoConfig.java
+++ b/src/main/java/com/mercadopago/MercadoPagoConfig.java
@@ -15,7 +15,7 @@ import org.apache.http.client.HttpRequestRetryHandler;
 /** Mercado Pago configuration class. */
 public class MercadoPagoConfig {
 
-  public static final String CURRENT_VERSION = "2.1.16";
+  public static final String CURRENT_VERSION = "2.1.17";
 
   public static final String PRODUCT_ID = "BC32A7VTRPP001U8NHJ0";
 

--- a/src/main/java/com/mercadopago/resources/payment/PaymentTransactionData.java
+++ b/src/main/java/com/mercadopago/resources/payment/PaymentTransactionData.java
@@ -11,7 +11,7 @@ public class PaymentTransactionData {
   /** QR code image in Base 64. */
   private String qrCodeBase64;
 
-  /** Transaction ID. */
+  /** BACEN identifier for Pix. */
   private String transactionId;
 
   /** Bank transfer ID. */

--- a/src/main/java/com/mercadopago/resources/payment/PaymentTransactionDetails.java
+++ b/src/main/java/com/mercadopago/resources/payment/PaymentTransactionDetails.java
@@ -32,4 +32,7 @@ public class PaymentTransactionDetails {
 
   /** Acquirer Reference. */
   private String acquirerReference;
+
+  /** BACEN identifier for Pix. */
+  private String transactionId;
 }


### PR DESCRIPTION
We need to add transaction id in SDK response.
That field contains BACEN identifier for Pix transactions.