### PR TITLE
[Feature] adding network transaction id related fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ already.
 <dependency>
   <groupId>com.mercadopago</groupId>
   <artifactId>sdk-java</artifactId>
-  <version>2.4.0</version>
+  <version>2.5.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.mercadopago</groupId>
     <artifactId>sdk-java</artifactId>
-    <version>2.4.0</version>
+    <version>2.5.0</version>
     <packaging>jar</packaging>
 
     <name>Mercadopago SDK</name>

--- a/src/main/java/com/mercadopago/MercadoPagoConfig.java
+++ b/src/main/java/com/mercadopago/MercadoPagoConfig.java
@@ -15,7 +15,7 @@ import org.apache.http.client.HttpRequestRetryHandler;
 /** Mercado Pago configuration class. */
 public class MercadoPagoConfig {
 
-  public static final String CURRENT_VERSION = "2.4.0";
+  public static final String CURRENT_VERSION = "2.5.0";
 
   public static final String PRODUCT_ID = "BC32A7VTRPP001U8NHJ0";
 

--- a/src/main/java/com/mercadopago/client/payment/PaymentForwardDataRequest.java
+++ b/src/main/java/com/mercadopago/client/payment/PaymentForwardDataRequest.java
@@ -11,4 +11,7 @@ public class PaymentForwardDataRequest  {
 
     /** ForwardData for SubMerchant */
     private final SubMerchant subMerchant;
+
+    /** Network transaction data for recurring payments with Visa/Master */
+    private final PaymentNetworkTransactionDataRequest networkTransactionData;
 }

--- a/src/main/java/com/mercadopago/client/payment/PaymentNetworkTransactionDataRequest.java
+++ b/src/main/java/com/mercadopago/client/payment/PaymentNetworkTransactionDataRequest.java
@@ -1,0 +1,12 @@
+package com.mercadopago.client.payment;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/** PaymentNetworkTransactionDataRequest class. */
+@Getter
+@Builder
+public class PaymentNetworkTransactionDataRequest {
+  /** Network transaction ID associated with the card brand identifier. */
+  private final String networkTransactionId;
+} 

--- a/src/main/java/com/mercadopago/resources/payment/Payment.java
+++ b/src/main/java/com/mercadopago/resources/payment/Payment.java
@@ -199,4 +199,7 @@ public class Payment extends MPResource {
    * merchant.
    */
   private Map<String, Object> internalMetadata;
+
+  /** Expanded information returned when using X-Expand-Response-Nodes header. */
+  private PaymentExpanded expanded;
 }

--- a/src/main/java/com/mercadopago/resources/payment/PaymentExpanded.java
+++ b/src/main/java/com/mercadopago/resources/payment/PaymentExpanded.java
@@ -1,0 +1,18 @@
+package com.mercadopago.resources.payment;
+
+import com.mercadopago.client.payment.PaymentNetworkTransactionDataRequest;
+import lombok.Getter;
+
+/** PaymentExpanded class. */
+@Getter
+public class PaymentExpanded {
+  /** Gateway information. */
+  private Gateway gateway;
+
+  /** Gateway class for expanded information. */
+  @Getter
+  public static class Gateway {
+    /** Reference information. */
+    private PaymentNetworkTransactionDataRequest reference;
+  }
+} 


### PR DESCRIPTION
Adding network_transaction_id related fields to payments request and response. [Documentation](https://www.mercadopago.com.br/developers/pt/docs/automatic-payments/recurring-charges/network-transaction-id)
Request:

```
forward_data: {
     network_transaction_data: {
       network_transaction_id: "xxxxxxx"
     }
   }
```
Response:

```
"expanded": {
   "gateway": {
 	  "reference": {
 		 "network_transaction_id": "xxxxx"
 	    }
    }
}
```