### PR TITLE
release(java): bump versão para 2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ already.
 <dependency>
   <groupId>com.mercadopago</groupId>
   <artifactId>sdk-java</artifactId>
-  <version>2.5.0</version>
+  <version>2.6.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.mercadopago</groupId>
     <artifactId>sdk-java</artifactId>
-    <version>2.5.0</version>
+    <version>2.6.0</version>
     <packaging>jar</packaging>
 
     <name>Mercadopago SDK</name>

--- a/src/main/java/com/mercadopago/MercadoPagoConfig.java
+++ b/src/main/java/com/mercadopago/MercadoPagoConfig.java
@@ -15,7 +15,7 @@ import org.apache.http.client.HttpRequestRetryHandler;
 /** Mercado Pago configuration class. */
 public class MercadoPagoConfig {
 
-  public static final String CURRENT_VERSION = "2.5.0";
+  public static final String CURRENT_VERSION = "2.6.0";
 
   public static final String PRODUCT_ID = "BC32A7VTRPP001U8NHJ0";
 


### PR DESCRIPTION
Atualizada a versão do SDK de 2.5.0 para 2.6.0 no arquivo pom.xml.

Atualizado o snippet de instalação no README.md para refletir a nova versão (2.6.0).

Atualizada a constante CURRENT_VERSION em 
[src/main/java/com/mercadopago/MercadoPagoConfig.java](https://meli-gpt.adminml.com/c/src/main/java/com/mercadopago/MercadoPagoConfig.java).