### PR TITLE
Fix dependency vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ already.
 <dependency>
   <groupId>com.mercadopago</groupId>
   <artifactId>sdk-java</artifactId>
-  <version>2.9.2</version>
+  <version>3.0.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
         <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-engine-core</artifactId>
-            <version>2.3</version>
+            <version>2.4.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.hsqldb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.mercadopago</groupId>
     <artifactId>sdk-java</artifactId>
-    <version>2.9.2</version>
+    <version>3.0.0</version>
     <packaging>jar</packaging>
 
     <name>Mercadopago SDK</name>

--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.3.1</version>
+            <version>5.4.3</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.9</version>
+            <version>2.11.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -198,19 +198,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.8.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.velocity</groupId>
-                    <artifactId>velocity</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-collections</groupId>
-                    <artifactId>commons-collections</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
         </dependency>
 
         <dependency>
@@ -301,12 +291,6 @@
             <artifactId>mockito-core</artifactId>
             <version>5.18.0</version>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-core</artifactId>
-            <version>3.9.6</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.26.2</version>
+            <version>1.27.1</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/mercadopago/MercadoPagoConfig.java
+++ b/src/main/java/com/mercadopago/MercadoPagoConfig.java
@@ -15,7 +15,7 @@ import org.apache.http.client.HttpRequestRetryHandler;
 /** Mercado Pago configuration class. */
 public class MercadoPagoConfig {
 
-  public static final String CURRENT_VERSION = "2.9.2";
+  public static final String CURRENT_VERSION = "3.0.0";
 
   public static final String PRODUCT_ID = "BC32A7VTRPP001U8NHJ0";
 


### PR DESCRIPTION
## Summary
Bumps third-party dependencies to remediate published CVEs and removes a long-standing `pom.xml` anomaly that mixed core/plugin coordinates with runtime dependencies.

## Changes
- Bump `httpclient5` 5.3.1 → 5.4.3 (CVE-2025-27820)
- Bump `commons-compress` 1.26.2 → 1.27.1 (CVE-2024-47554)
- Remove `maven-core` / `maven-javadoc-plugin` entries from runtime deps; declare `httpclient` v4 explicitly **(breaking)**
- Bump `gson` 2.8.9 → 2.11.0
- Bump `velocity-engine-core` 2.3 → 2.4.1

## Test plan
- [ ] CI green