### PR TITLE
feat(order): add missing AP fields to order request models (IXE-679)

### DIFF
--- a/src/main/java/com/mercadopago/client/order/OrderCreateRequest.java
+++ b/src/main/java/com/mercadopago/client/order/OrderCreateRequest.java
@@ -69,4 +69,7 @@ public class OrderCreateRequest extends MPResource {
 
     /** Shipment details for the order, including receiver address and package dimensions. */
     private OrderShipmentRequest shipment;
+
+    /** Integration metadata identifying the integrator, platform, corporation, and sponsor. */
+    private OrderIntegrationDataRequest integrationData;
 }

--- a/src/main/java/com/mercadopago/client/order/OrderIntegrationDataRequest.java
+++ b/src/main/java/com/mercadopago/client/order/OrderIntegrationDataRequest.java
@@ -1,0 +1,28 @@
+package com.mercadopago.client.order;
+
+import lombok.Builder;
+import lombok.Getter;
+
+// API version: acd67b14-97c4-4a4a-840d-0a018c09654f
+
+/**
+ * Request object containing integration metadata for an order. Identifies the integrator,
+ * platform, and corporation associated with the integration, as well as any sponsoring
+ * marketplace owner.
+ */
+@Getter
+@Builder
+public class OrderIntegrationDataRequest {
+
+  /** Identifier of the certified integrator. Type: String. */
+  private String integratorId;
+
+  /** Platform identifier assigned by MercadoPago. Type: String. */
+  private String platformId;
+
+  /** Corporation identifier for multi-account setups. Type: String. */
+  private String corporationId;
+
+  /** Sponsor (marketplace owner) information. */
+  private OrderSponsorRequest sponsor;
+}

--- a/src/main/java/com/mercadopago/client/order/OrderPayerAddressRequest.java
+++ b/src/main/java/com/mercadopago/client/order/OrderPayerAddressRequest.java
@@ -29,4 +29,7 @@ public class OrderPayerAddressRequest {
 
     /** Name of the state or province. */
     private String state;
+
+    /** Apartment number, floor, or other additional address information. Type: String. */
+    private String complement;
 }

--- a/src/main/java/com/mercadopago/client/order/OrderPaymentRequest.java
+++ b/src/main/java/com/mercadopago/client/order/OrderPaymentRequest.java
@@ -20,6 +20,13 @@ public class OrderPaymentRequest {
     /** ISO 8601 duration or date-time indicating when this payment expires. */
     private String expirationTime;
 
+    /**
+     * Absolute date and time (ISO 8601) after which this payment can no longer be collected.
+     * Distinct from expirationTime, which is a relative duration or TTL.
+     * Type: String (ISO 8601, e.g. "2026-06-01T00:00:00.000-04:00").
+     */
+    private String dateOfExpiration;
+
     /** Payment method details including type, token, and installments. */
     private OrderPaymentMethodRequest paymentMethod;
 

--- a/src/main/java/com/mercadopago/client/order/OrderSponsorRequest.java
+++ b/src/main/java/com/mercadopago/client/order/OrderSponsorRequest.java
@@ -1,0 +1,18 @@
+package com.mercadopago.client.order;
+
+import lombok.Builder;
+import lombok.Getter;
+
+// API version: acd67b14-97c4-4a4a-840d-0a018c09654f
+
+/**
+ * Request object representing the sponsor (marketplace owner) associated with an order's
+ * integration metadata.
+ */
+@Getter
+@Builder
+public class OrderSponsorRequest {
+
+  /** MercadoPago user ID of the sponsoring marketplace owner. Type: String. */
+  private String id;
+}

--- a/src/main/java/com/mercadopago/client/order/OrderStoredCredentialRequest.java
+++ b/src/main/java/com/mercadopago/client/order/OrderStoredCredentialRequest.java
@@ -26,4 +26,11 @@ public class OrderStoredCredentialRequest {
 
   /** Whether this is the first payment using this stored credential. */
   private Boolean firstPayment;
+
+  /**
+   * Reference to the previous transaction in a recurring series. Required from the second charge
+   * onwards to link this payment to the original card-network authorization.
+   * Type: String (transaction ID).
+   */
+  private String prevTransactionRef;
 }


### PR DESCRIPTION
## Summary

- **OrderStoredCredentialRequest** → added `prevTransactionRef: String` — links each recurring charge to the original card-network authorization; required from the second charge onwards in the AP flow.
- **OrderPaymentRequest** → added `dateOfExpiration: String` (ISO 8601) — absolute payment expiry date, distinct from the relative `expirationTime` TTL.
- **OrderPayerAddressRequest** → added `complement: String` — apartment or floor; already present in Go, .NET and Node.js SDKs.
- **OrderIntegrationDataRequest** (new class) → `integratorId`, `platformId`, `corporationId` (String) + `sponsor: OrderSponsorRequest`.
- **OrderSponsorRequest** (new class) → `id: String`.
- **OrderCreateRequest** → added `integrationData: OrderIntegrationDataRequest`.

## Context

Part of IXE-679: fields required for the Automatic Payments flow in the Orders API were missing from the public SDKs. Companion PRs exist for Go, .NET, Node.js, PHP, Python and Ruby.

All changes are additive only — no existing fields were renamed or removed.

## Test plan

- [x] mvn test -Dtest=OrderClientTest — 25 tests, 0 failures
- [x] mvn compile — 0 errors
- [ ] Integration tests (not run per policy)

Generated with [Claude Code](https://claude.com/claude-code)