### PR TITLE
Fix installments field serialized as 0 for bank_transfer payment methods

### DIFF
--- a/src/main/java/com/mercadopago/client/order/OrderPaymentMethodRequest.java
+++ b/src/main/java/com/mercadopago/client/order/OrderPaymentMethodRequest.java
@@ -24,7 +24,7 @@ public class OrderPaymentMethodRequest {
     private String token;
 
     /** Number of installments selected for the payment. */
-    private int installments;
+    private Integer installments;
 
     /** Text that will appear on the cardholder's billing statement (e.g. "MERCADOPAGO"). */
     private String statementDescriptor;

--- a/src/test/java/com/mercadopago/client/order/OrderClientTest.java
+++ b/src/test/java/com/mercadopago/client/order/OrderClientTest.java
@@ -499,6 +499,38 @@ class OrderClientTest extends BaseClientTest {
         Assertions.assertEquals("boleto", paymentMethodJson.get("id").getAsString());
     }
 
+    @Test
+    void orderPixPaymentMethodDoesNotIncludeInstallments() throws Exception {
+        OrderPaymentMethodRequest paymentMethod = OrderPaymentMethodRequest.builder()
+                .type("bank_transfer")
+                .id("pix")
+                .build();
+
+        OrderPaymentRequest payment = OrderPaymentRequest.builder()
+                .amount("10.50")
+                .paymentMethod(paymentMethod)
+                .build();
+
+        OrderCreateRequest request = OrderCreateRequest.builder()
+                .type("online")
+                .totalAmount("10.50")
+                .transactions(OrderTransactionRequest.builder().payments(Arrays.asList(payment)).build())
+                .payer(OrderPayerRequest.builder().email("test@email.com").build())
+                .build();
+
+        JsonObject paymentMethodJson = Serializer
+                .serializeToJson(request)
+                .getAsJsonObject("transactions")
+                .getAsJsonArray("payments")
+                .get(0).getAsJsonObject()
+                .getAsJsonObject("payment_method");
+
+        Assertions.assertEquals("bank_transfer", paymentMethodJson.get("type").getAsString());
+        Assertions.assertEquals("pix", paymentMethodJson.get("id").getAsString());
+        Assertions.assertFalse(paymentMethodJson.has("installments"),
+                "installments must not be present in the JSON for bank_transfer payment methods");
+    }
+
   @Test
   void searchSuccess() throws MPException, MPApiException, IOException {
     HttpResponse httpResponse =


### PR DESCRIPTION
Change installments from primitive int to Integer in OrderPaymentMethodRequest so Gson omits the field when not explicitly set. This prevents a 400 error from the API when creating PIX payments, which rejects the unsupported installments property on bank_transfer.