### PR TITLE
fix(webhook): preserve data.id case in signature manifest

### DIFF
--- a/src/main/java/com/mercadopago/webhook/WebhookSignatureValidator.java
+++ b/src/main/java/com/mercadopago/webhook/WebhookSignatureValidator.java
@@ -53,7 +53,7 @@ public final class WebhookSignatureValidator {
    *                   manifest before computing the HMAC
    * @param dataId     value of the {@code data.id} query parameter; may be {@code null} or
    *                   blank, in which case the {@code id:} pair is omitted. When present,
-   *                   it is lowercased before being included in the manifest
+   *                   it is included in the manifest exactly as received
    * @param secret     secret signature configured for the application in Tus Integraciones,
    *                   used as the HMAC key
    * @throws MPInvalidWebhookSignatureException when the signature is missing, malformed, or
@@ -201,7 +201,7 @@ public final class WebhookSignatureValidator {
   private static String buildManifest(String dataId, String requestId, String timestamp) {
     StringBuilder sb = new StringBuilder();
     if (dataId != null) {
-      sb.append("id:").append(dataId.toLowerCase()).append(';');
+      sb.append("id:").append(dataId).append(';');
     }
     if (requestId != null) {
       sb.append("request-id:").append(requestId).append(';');

--- a/src/test/java/com/mercadopago/webhook/WebhookSignatureValidatorTest.java
+++ b/src/test/java/com/mercadopago/webhook/WebhookSignatureValidatorTest.java
@@ -27,7 +27,7 @@ class WebhookSignatureValidatorTest {
     try {
       StringBuilder mb = new StringBuilder();
       if (dataId != null && !dataId.isEmpty()) {
-        mb.append("id:").append(dataId.toLowerCase()).append(';');
+        mb.append("id:").append(dataId).append(';');
       }
       if (requestId != null && !requestId.isEmpty()) {
         mb.append("request-id:").append(requestId).append(';');
@@ -68,9 +68,10 @@ class WebhookSignatureValidatorTest {
 
   // case 2
   @Test
-  void uppercaseDataIdIsLowercased() {
+  void uppercaseDataIdIsPreserved() {
+    String upperHash = computeHash(DATA_ID_RAW, REQUEST_ID, TS, SECRET);
     assertDoesNotThrow(() ->
-        WebhookSignatureValidator.validate(buildHeader(validHash()), REQUEST_ID, DATA_ID_RAW, SECRET));
+        WebhookSignatureValidator.validate(buildHeader(upperHash), REQUEST_ID, DATA_ID_RAW, SECRET));
   }
 
   // case 3


### PR DESCRIPTION
## Problem

`WebhookSignatureValidator.validate` was calling `.toLowerCase()` on `dataId` before building the HMAC manifest. MercadoPago signs webhook notifications using the original casing of `data.id`, so any notification with uppercase or mixed-case identifiers would fail validation with `SignatureMismatch`.

## Fix

Remove the `.toLowerCase()` call in `buildManifest` so the value is included exactly as received. The Javadoc is updated accordingly.

## Testing

Verified manually with `data.id` values in uppercase (`ORDER123`), lowercase (`order123`), and mixed case (`oRdEr`) — all pass when the signature was generated with the same casing.