### PR TITLE
fix: escape dynamic API path parameters

### DIFF
--- a/src/main/java/com/mercadopago/client/MercadoPagoClient.java
+++ b/src/main/java/com/mercadopago/client/MercadoPagoClient.java
@@ -16,6 +16,8 @@ import com.mercadopago.net.MPRequest;
 import com.mercadopago.net.MPResponse;
 import com.mercadopago.net.MPSearchRequest;
 import com.mercadopago.net.UrlFormatter;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -78,6 +80,20 @@ public abstract class MercadoPagoClient {
         String.format("MercadoPago Java SDK/%s", MercadoPagoConfig.CURRENT_VERSION));
     defaultHeaders.put(Headers.TRACKING_ID, MercadoPagoConfig.TRACKING_ID);
     defaultHeaders.put(Headers.CONTENT_TYPE, CONTENT_TYPE_HEADER_VALUE);
+  }
+
+  /**
+   * Encodes a dynamic URL path segment before it is interpolated into an endpoint path.
+   *
+   * @param value path parameter value
+   * @return encoded path segment
+   */
+  protected static String encodePathParam(Object value) {
+    try {
+      return URLEncoder.encode(String.valueOf(value), "UTF-8").replace("+", "%20");
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalStateException("UTF-8 encoding is not supported", e);
+    }
   }
 
   /**

--- a/src/main/java/com/mercadopago/client/chargeback/ChargebackClient.java
+++ b/src/main/java/com/mercadopago/client/chargeback/ChargebackClient.java
@@ -88,7 +88,7 @@ public class ChargebackClient extends MercadoPagoClient {
       throws MPException, MPApiException {
     LOGGER.info("Sending get chargeback request");
     MPResponse response =
-        send(String.format(URL_WITH_ID, id), HttpMethod.GET, null, null, requestOptions);
+        send(String.format(URL_WITH_ID, encodePathParam(id)), HttpMethod.GET, null, null, requestOptions);
 
     Chargeback result = deserializeFromJson(Chargeback.class, response.getContent());
     result.setResponse(response);

--- a/src/main/java/com/mercadopago/client/customer/CustomerCardClient.java
+++ b/src/main/java/com/mercadopago/client/customer/CustomerCardClient.java
@@ -68,7 +68,7 @@ public class CustomerCardClient extends MercadoPagoClient {
    * @throws MPApiException if the API returns a non-successful HTTP status code
    */
   public CustomerCard get(String customerId, String cardId) throws MPException, MPApiException {
-    return this.get(customerId, cardId, null);
+    return this.get(customerId, encodePathParam(cardId), null);
   }
 
   /**
@@ -86,7 +86,7 @@ public class CustomerCardClient extends MercadoPagoClient {
       throws MPException, MPApiException {
     MPResponse response =
         send(
-            String.format("/v1/customers/%s/cards/%s", customerId, cardId),
+            String.format("/v1/customers/%s/cards/%s", encodePathParam(customerId), encodePathParam(cardId)),
             HttpMethod.GET,
             null,
             null,
@@ -129,7 +129,7 @@ public class CustomerCardClient extends MercadoPagoClient {
     JsonObject payload = Serializer.serializeToJson(request);
     MPRequest mpRequest =
         MPRequest.buildRequest(
-            String.format("/v1/customers/%s/cards", customerId),
+            String.format("/v1/customers/%s/cards", encodePathParam(customerId)),
             HttpMethod.POST,
             payload,
             null,
@@ -151,7 +151,7 @@ public class CustomerCardClient extends MercadoPagoClient {
    * @throws MPApiException if the API returns a non-successful HTTP status code
    */
   public CustomerCard delete(String customerId, String cardId) throws MPException, MPApiException {
-    return this.delete(customerId, cardId, null);
+    return this.delete(customerId, encodePathParam(cardId), null);
   }
 
   /**
@@ -171,7 +171,7 @@ public class CustomerCardClient extends MercadoPagoClient {
 
     MPResponse response =
         send(
-            String.format("/v1/customers/%s/cards/%s", customerId, cardId),
+            String.format("/v1/customers/%s/cards/%s", encodePathParam(customerId), encodePathParam(cardId)),
             HttpMethod.DELETE,
             null,
             null,
@@ -210,7 +210,7 @@ public class CustomerCardClient extends MercadoPagoClient {
     LOGGER.info("Sending list all customer cards request");
     MPResponse response =
         list(
-            String.format("/v1/customers/%s/cards", customerId),
+            String.format("/v1/customers/%s/cards", encodePathParam(customerId)),
             HttpMethod.GET,
             null,
             null,

--- a/src/main/java/com/mercadopago/client/customer/CustomerClient.java
+++ b/src/main/java/com/mercadopago/client/customer/CustomerClient.java
@@ -107,7 +107,7 @@ public class CustomerClient extends MercadoPagoClient {
 
     MPResponse response =
         send(
-            String.format("/v1/customers/%s", customerId),
+            String.format("/v1/customers/%s", encodePathParam(customerId)),
             HttpMethod.GET,
             null,
             null,
@@ -199,7 +199,7 @@ public class CustomerClient extends MercadoPagoClient {
     JsonObject payload = Serializer.serializeToJson(request);
     MPRequest mpRequest =
         MPRequest.buildRequest(
-            String.format("/v1/customers/%s", customerId),
+            String.format("/v1/customers/%s", encodePathParam(customerId)),
             HttpMethod.PUT,
             payload,
             null,
@@ -239,7 +239,7 @@ public class CustomerClient extends MercadoPagoClient {
 
     MPRequest mpRequest =
         MPRequest.buildRequest(
-            String.format("/v1/customers/%s", customerId),
+            String.format("/v1/customers/%s", encodePathParam(customerId)),
             HttpMethod.DELETE,
             null,
             null,

--- a/src/main/java/com/mercadopago/client/invoice/InvoiceClient.java
+++ b/src/main/java/com/mercadopago/client/invoice/InvoiceClient.java
@@ -88,7 +88,7 @@ public class InvoiceClient extends MercadoPagoClient {
       throws MPException, MPApiException {
     LOGGER.info("Sending get invoice request");
     MPResponse response =
-        send(String.format(URL_WITH_ID, id), HttpMethod.GET, null, null, requestOptions);
+        send(String.format(URL_WITH_ID, encodePathParam(id)), HttpMethod.GET, null, null, requestOptions);
 
     Invoice result = deserializeFromJson(Invoice.class, response.getContent());
     result.setResponse(response);

--- a/src/main/java/com/mercadopago/client/order/OrderClient.java
+++ b/src/main/java/com/mercadopago/client/order/OrderClient.java
@@ -154,7 +154,7 @@ public class OrderClient extends MercadoPagoClient {
 
     validateOrderID(id);
 
-    String url = String.format(URL_WITH_ID, id);
+    String url = String.format(URL_WITH_ID, encodePathParam(id));
     MPResponse response = send(url, HttpMethod.GET, null, null, requestOptions);
 
     Order result = deserializeFromJson(Order.class, response.getContent());
@@ -193,7 +193,7 @@ public class OrderClient extends MercadoPagoClient {
 
     validateOrderID(id);
 
-    String url = String.format(URL_PROCESS, id);
+    String url = String.format(URL_PROCESS, encodePathParam(id));
     MPResponse response = send(url, HttpMethod.POST, null, null, requestOptions);
 
     Order result = deserializeFromJson(Order.class, response.getContent());
@@ -234,7 +234,7 @@ public class OrderClient extends MercadoPagoClient {
 
     MPRequest mpRequest =
         MPRequest.builder()
-            .uri(String.format(URL_TRANSACTION, orderId))
+            .uri(String.format(URL_TRANSACTION, encodePathParam(orderId)))
             .method(HttpMethod.POST)
             .payload(Serializer.serializeToJson(request))
             .build();
@@ -259,7 +259,7 @@ public class OrderClient extends MercadoPagoClient {
   public UpdateOrderTransaction updateTransaction(
       String orderId, String transactionId, OrderPaymentRequest request)
       throws MPException, MPApiException {
-    return this.updateTransaction(orderId, transactionId, request, null);
+    return this.updateTransaction(orderId, encodePathParam(transactionId), request, null);
   }
 
   /**
@@ -289,7 +289,7 @@ public class OrderClient extends MercadoPagoClient {
 
     MPRequest mpRequest =
         MPRequest.builder()
-            .uri(String.format(URL_TRANSACTION_WITH_ID, orderId, transactionId))
+            .uri(String.format(URL_TRANSACTION_WITH_ID, encodePathParam(orderId), encodePathParam(transactionId)))
             .method(HttpMethod.PUT)
             .payload(Serializer.serializeToJson(request))
             .build();
@@ -331,7 +331,7 @@ public class OrderClient extends MercadoPagoClient {
 
     validateOrderID(orderId);
 
-    String url = String.format(URL_CANCEL, orderId);
+    String url = String.format(URL_CANCEL, encodePathParam(orderId));
     MPResponse response = send(url, HttpMethod.POST, null, null, requestOptions);
 
     Order result = deserializeFromJson(Order.class, response.getContent());
@@ -369,7 +369,7 @@ public class OrderClient extends MercadoPagoClient {
 
     validateOrderID(orderId);
 
-    String url = String.format(URL_CAPTURE, orderId);
+    String url = String.format(URL_CAPTURE, encodePathParam(orderId));
     MPResponse response = send(url, HttpMethod.POST, null, null, requestOptions);
 
     Order result = deserializeFromJson(Order.class, response.getContent());
@@ -389,7 +389,7 @@ public class OrderClient extends MercadoPagoClient {
    */
   public OrderTransaction deleteTransaction(String orderId, String transactionId)
       throws MPException, MPApiException {
-    return this.deleteTransaction(orderId, transactionId, null);
+    return this.deleteTransaction(orderId, encodePathParam(transactionId), null);
   }
 
   /**
@@ -413,7 +413,7 @@ public class OrderClient extends MercadoPagoClient {
     validateOrderID(orderId);
     validateTransactionID(transactionId);
 
-    String url = String.format(URL_TRANSACTION_WITH_ID, orderId, transactionId);
+    String url = String.format(URL_TRANSACTION_WITH_ID, encodePathParam(orderId), encodePathParam(transactionId));
     MPResponse response = send(url, HttpMethod.DELETE, null, null, requestOptions);
 
     OrderTransaction result = new OrderTransaction();
@@ -489,7 +489,7 @@ public class OrderClient extends MercadoPagoClient {
 
     MPRequest mpRequest =
         MPRequest.builder()
-            .uri(String.format(URL_REFUND, orderId))
+            .uri(String.format(URL_REFUND, encodePathParam(orderId)))
             .method(HttpMethod.POST)
             .payload(payload)
             .build();

--- a/src/main/java/com/mercadopago/client/point/PointClient.java
+++ b/src/main/java/com/mercadopago/client/point/PointClient.java
@@ -133,7 +133,7 @@ public class PointClient extends MercadoPagoClient {
 
     MPRequest mpRequest =
         MPRequest.builder()
-            .uri(String.format(PAYMENT_INTENT_URL, deviceId))
+            .uri(String.format(PAYMENT_INTENT_URL, encodePathParam(deviceId)))
             .method(HttpMethod.POST)
             .payload(Serializer.serializeToJson(request))
             .build();
@@ -210,7 +210,7 @@ public class PointClient extends MercadoPagoClient {
    */
   public PointCancelPaymentIntent cancelPaymentIntent(String deviceId, String paymentIntentId)
       throws MPException, MPApiException {
-    return this.cancelPaymentIntent(deviceId, paymentIntentId, null);
+    return this.cancelPaymentIntent(deviceId, encodePathParam(paymentIntentId), null);
   }
 
   /**
@@ -234,7 +234,7 @@ public class PointClient extends MercadoPagoClient {
 
     MPRequest mpRequest =
         MPRequest.builder()
-            .uri(String.format(PAYMENT_INTENT_DELETE_URL, deviceId, paymentIntentId))
+            .uri(String.format(PAYMENT_INTENT_DELETE_URL, encodePathParam(deviceId), encodePathParam(paymentIntentId)))
             .method(HttpMethod.DELETE)
             .build();
 
@@ -281,7 +281,7 @@ public class PointClient extends MercadoPagoClient {
 
     MPRequest mpRequest =
         MPRequest.builder()
-            .uri(String.format(PAYMENT_INTENT_SEARCH_URL, paymentIntentId))
+            .uri(String.format(PAYMENT_INTENT_SEARCH_URL, encodePathParam(paymentIntentId)))
             .method(HttpMethod.GET)
             .build();
 
@@ -328,7 +328,7 @@ public class PointClient extends MercadoPagoClient {
 
     MPRequest mpRequest =
         MPRequest.builder()
-            .uri(String.format(PAYMENT_INTENT_STATUS_URL, paymentIntentId))
+            .uri(String.format(PAYMENT_INTENT_STATUS_URL, encodePathParam(paymentIntentId)))
             .method(HttpMethod.GET)
             .build();
 
@@ -424,7 +424,7 @@ public class PointClient extends MercadoPagoClient {
 
     MPRequest mpRequest =
         MPRequest.builder()
-            .uri(String.format(DEVICE_WITH_ID_URL, deviceId))
+            .uri(String.format(DEVICE_WITH_ID_URL, encodePathParam(deviceId)))
             .method(HttpMethod.PATCH)
             .payload(Serializer.serializeToJson(request))
             .build();

--- a/src/main/java/com/mercadopago/client/preapproval/PreapprovalClient.java
+++ b/src/main/java/com/mercadopago/client/preapproval/PreapprovalClient.java
@@ -92,7 +92,7 @@ public class PreapprovalClient extends MercadoPagoClient {
       throws MPException, MPApiException {
     LOGGER.info("Sending get preapproval request");
     MPResponse response =
-        send(String.format(URL_WITH_ID, id), HttpMethod.GET, null, null, requestOptions);
+        send(String.format(URL_WITH_ID, encodePathParam(id)), HttpMethod.GET, null, null, requestOptions);
 
     Preapproval result = deserializeFromJson(Preapproval.class, response.getContent());
     result.setResponse(response);
@@ -167,7 +167,7 @@ public class PreapprovalClient extends MercadoPagoClient {
     LOGGER.info("Sending update preapproval request");
     MPResponse response =
         send(
-            String.format(URL_WITH_ID, id),
+            String.format(URL_WITH_ID, encodePathParam(id)),
             HttpMethod.PUT,
             serializeToJson(request),
             null,

--- a/src/main/java/com/mercadopago/client/preapprovalplan/PreApprovalPlanClient.java
+++ b/src/main/java/com/mercadopago/client/preapprovalplan/PreApprovalPlanClient.java
@@ -93,7 +93,7 @@ public class PreApprovalPlanClient extends MercadoPagoClient {
       throws MPException, MPApiException {
     LOGGER.info("Sending get preapproval plan request");
     MPResponse response =
-        send(String.format(URL_WITH_ID, id), HttpMethod.GET, null, null, requestOptions);
+        send(String.format(URL_WITH_ID, encodePathParam(id)), HttpMethod.GET, null, null, requestOptions);
 
     PreApprovalPlan result = deserializeFromJson(PreApprovalPlan.class, response.getContent());
     result.setResponse(response);
@@ -161,7 +161,7 @@ public class PreApprovalPlanClient extends MercadoPagoClient {
       MPRequestOptions requestOptions) throws MPException, MPApiException {
     LOGGER.info("Sending update preapproval plan request");
     MPResponse response =
-        send(String.format(URL_WITH_ID, id), HttpMethod.PUT, serializeToJson(request), null,
+        send(String.format(URL_WITH_ID, encodePathParam(id)), HttpMethod.PUT, serializeToJson(request), null,
             requestOptions);
 
     PreApprovalPlan result = deserializeFromJson(PreApprovalPlan.class, response.getContent());

--- a/src/main/java/com/mercadopago/client/preference/PreferenceClient.java
+++ b/src/main/java/com/mercadopago/client/preference/PreferenceClient.java
@@ -101,7 +101,7 @@ public class PreferenceClient extends MercadoPagoClient {
       throws MPException, MPApiException {
     LOGGER.info("Sending get preference request");
     MPResponse response =
-        send(String.format(URL_WITH_ID, id), HttpMethod.GET, null, null, requestOptions);
+        send(String.format(URL_WITH_ID, encodePathParam(id)), HttpMethod.GET, null, null, requestOptions);
 
     Preference result = deserializeFromJson(Preference.class, response.getContent());
     result.setResponse(response);
@@ -194,7 +194,7 @@ public class PreferenceClient extends MercadoPagoClient {
 
     MPRequest mpRequest =
         MPRequest.builder()
-            .uri(String.format(URL_WITH_ID, id))
+            .uri(String.format(URL_WITH_ID, encodePathParam(id)))
             .method(HttpMethod.PUT)
             .payload(Serializer.serializeToJson(request))
             .build();

--- a/src/test/java/com/mercadopago/client/MercadoPagoClientTest.java
+++ b/src/test/java/com/mercadopago/client/MercadoPagoClientTest.java
@@ -291,6 +291,13 @@ public class MercadoPagoClientTest extends BaseClientTest {
     assertEquals(200, (int) mpResponse.getStatusCode());
   }
 
+  @Test
+  public void encodePathParamEscapesPathTraversal() {
+    assertEquals(
+        "..%2F..%2Fapplications%2F123",
+        testClient.encodePathParamRequest("../../applications/123"));
+  }
+
   private static class TestClient extends MercadoPagoClient {
 
     /**
@@ -329,6 +336,10 @@ public class MercadoPagoClientTest extends BaseClientTest {
         MPRequestOptions requestOptions)
         throws MPException, MPApiException {
       return list(path, method, payload, queryParams, requestOptions);
+    }
+
+    public String encodePathParamRequest(String value) {
+      return encodePathParam(value);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds a shared path-parameter encoder in the base MercadoPago client.
- Applies encoding to dynamic IDs across affected resource clients.
- Adds regression coverage for traversal-style path parameters.

## Validation
- `mvn -q -Dtest=com.mercadopago.client.MercadoPagoClientTest#encodePathParamEscapesPathTraversal test`