### PR TITLE
Bump version to 3.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ already.
 <dependency>
   <groupId>com.mercadopago</groupId>
   <artifactId>sdk-java</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.mercadopago</groupId>
     <artifactId>sdk-java</artifactId>
-    <version>3.3.0</version>
+    <version>3.3.1</version>
     <packaging>jar</packaging>
 
     <name>Mercadopago SDK</name>

--- a/src/main/java/com/mercadopago/MercadoPagoConfig.java
+++ b/src/main/java/com/mercadopago/MercadoPagoConfig.java
@@ -35,7 +35,7 @@ import org.apache.http.client.HttpRequestRetryHandler;
  */
 public class MercadoPagoConfig {
 
-  public static final String CURRENT_VERSION = "3.3.0";
+  public static final String CURRENT_VERSION = "3.3.1";
 
   /** Internal MercadoPago product identifier sent in every API request for analytics. */
   public static final String PRODUCT_ID = "BC32A7VTRPP001U8NHJ0";


### PR DESCRIPTION
## Summary
- Bump patch version from 3.3.0 to 3.3.1

## Files changed
- `pom.xml` — version updated to 3.3.1
- `src/main/java/com/mercadopago/MercadoPagoConfig.java` — `CURRENT_VERSION` updated to 3.3.1
- `README.md` — maven dependency version updated to 3.3.1

## Test plan
- [ ] Verify CI passes
- [ ] Confirm version string is correct in all files