### PR TITLE
Pin GitHub Actions to SHA for supply chain security

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -32,7 +32,7 @@ jobs:
 
       - name: Dependency Review
         if: github.event_name == 'pull_request'
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
         with:
           fail-on-severity: high
 

--- a/.github/workflows/maven-publish-release.yml
+++ b/.github/workflows/maven-publish-release.yml
@@ -15,9 +15,9 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Set up JDK 11
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:
           java-version: '11'
           distribution: 'temurin'

--- a/.github/workflows/maven-publish-snapshot.yml
+++ b/.github/workflows/maven-publish-snapshot.yml
@@ -16,9 +16,9 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Set up JDK 11
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:
           java-version: '11'
           distribution: 'temurin'


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to full SHA commit hashes to prevent supply chain attacks via mutable tags

## Changes
- `main.yml`: `actions/checkout@v7` → `@9c091bb2...`, `actions/setup-java@v5` → `@1bcf9fb1...`, `actions/dependency-review-action@v5` → `@a1d282b3...`
- `maven-publish-release.yml`: `actions/checkout@v7` → `@9c091bb2...`, `actions/setup-java@v5` → `@1bcf9fb1...`
- `maven-publish-snapshot.yml`: `actions/checkout@v7` → `@9c091bb2...`, `actions/setup-java@v5` → `@1bcf9fb1...`

## Test plan
- [ ] CI passes on this PR