### PR TITLE
Add CREDENTIAL_ON_FILE messaging fields to Payment types

### DIFF
--- a/src/main/java/com/mercadopago/client/payment/PaymentReferenceRequest.java
+++ b/src/main/java/com/mercadopago/client/payment/PaymentReferenceRequest.java
@@ -1,0 +1,15 @@
+package com.mercadopago.client.payment;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Request object carrying a credential-on-file reference identifier.
+ * Used within transaction data to link the current payment to a stored credential.
+ */
+@Getter
+@Builder
+public class PaymentReferenceRequest {
+  /** Identifier of the stored credential reference. */
+  private String id;
+}

--- a/src/main/java/com/mercadopago/client/payment/PaymentTransactionDataRequest.java
+++ b/src/main/java/com/mercadopago/client/payment/PaymentTransactionDataRequest.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 
 /**
  * Request object containing transaction data associated with the point of interaction.
- * Carries subscription and recurring-payment details such as sequence, billing
- * period, and payment references.
+ * Carries subscription, recurring-payment, and credential-on-file details such as
+ * sequence, billing period, and payment references.
  */
 @Getter
 @Builder
@@ -23,4 +23,25 @@ public class PaymentTransactionDataRequest {
   private PaymentPaymentReferenceRequest paymentReference;
   /** Billing date for the current invoice period (e.g. "2023-01-15"). */
   private String billingDate;
+  /**
+   * Whether this is the first transaction for a CREDENTIAL_ON_FILE payment.
+   * Replaces the legacy {@code firstTimeUse} field in new integrations.
+   */
+  private boolean firstTransaction;
+  /**
+   * Storage mode for the credential in a CREDENTIAL_ON_FILE flow.
+   * Accepted values: {@code "store"} (storing a new credential) or
+   * {@code "stored"} (using an already stored credential).
+   */
+  private String storage;
+  /**
+   * Indicates who initiated the transaction in a CREDENTIAL_ON_FILE flow.
+   * Accepted values: {@code "customer"} or {@code "merchant"}.
+   */
+  private String transactionInitiator;
+  /**
+   * Reference to the stored credential used in a CREDENTIAL_ON_FILE flow.
+   * Contains the identifier of the credential being referenced.
+   */
+  private PaymentReferenceRequest reference;
 }

--- a/src/main/java/com/mercadopago/resources/payment/PaymentReference.java
+++ b/src/main/java/com/mercadopago/resources/payment/PaymentReference.java
@@ -1,0 +1,17 @@
+package com.mercadopago.resources.payment;
+
+import lombok.Getter;
+
+/**
+ * Resource that holds a credential-on-file reference identifier for a MercadoPago payment.
+ *
+ * <p>Used in CREDENTIAL_ON_FILE flows to link the current payment to a stored
+ * payment credential.
+ *
+ * @see PaymentTransactionData#getReference()
+ */
+@Getter
+public class PaymentReference {
+  /** Unique identifier of the stored credential reference. */
+  private String id;
+}

--- a/src/main/java/com/mercadopago/resources/payment/PaymentTransactionData.java
+++ b/src/main/java/com/mercadopago/resources/payment/PaymentTransactionData.java
@@ -6,8 +6,9 @@ import lombok.Getter;
  * Resource that holds transaction-level data from the point of interaction for a MercadoPago payment.
  *
  * <p>Contains QR code information for Pix payments, bank transfer details, ticket URLs for
- * offline payment methods, and subscription-related data for recurring payments. This data
- * is typically provided within the {@link PaymentPointOfInteraction} resource.
+ * offline payment methods, subscription-related data for recurring payments, and
+ * credential-on-file fields for CREDENTIAL_ON_FILE flows. This data is typically provided
+ * within the {@link PaymentPointOfInteraction} resource.
  *
  * @see PaymentPointOfInteraction#getTransactionData()
  */
@@ -51,4 +52,29 @@ public class PaymentTransactionData {
 
   /** Billing date for subscription or recurring payment invoices. */
   private String billingDate;
+
+  /**
+   * Whether this is the first transaction for a CREDENTIAL_ON_FILE payment.
+   * Replaces the legacy {@code firstTimeUse} field in new integrations.
+   */
+  private boolean firstTransaction;
+
+  /**
+   * Storage mode for the credential in a CREDENTIAL_ON_FILE flow.
+   * Possible values: {@code "store"} (storing a new credential) or
+   * {@code "stored"} (using an already stored credential).
+   */
+  private String storage;
+
+  /**
+   * Indicates who initiated the transaction in a CREDENTIAL_ON_FILE flow.
+   * Possible values: {@code "customer"} or {@code "merchant"}.
+   */
+  private String transactionInitiator;
+
+  /**
+   * Reference to the stored credential used in a CREDENTIAL_ON_FILE flow.
+   * Contains the identifier of the credential being referenced.
+   */
+  private PaymentReference reference;
 }


### PR DESCRIPTION
## Summary

- Add four new fields to `PaymentTransactionDataRequest` and `PaymentTransactionData` to support the `CREDENTIAL_ON_FILE` point-of-interaction type, which replaces the legacy `SUBSCRIPTIONS` type:
  - `firstTransaction` (`boolean`): marks whether this is the first transaction with a stored credential
  - `storage` (`String`): `"store"` when saving a new credential, `"stored"` when using an existing one
  - `transactionInitiator` (`String`): who initiated the transaction — `"customer"` or `"merchant"`
  - `reference` (`PaymentReferenceRequest` / `PaymentReference`): carries the `id` of the stored credential reference (JSON key `reference`, not `payment_reference`)
- Add two new companion classes following existing SDK patterns:
  - `PaymentReferenceRequest` (client package, `@Getter @Builder`)
  - `PaymentReference` (resources package, `@Getter`)
- `PaymentPointOfInteraction` already has `subType` — no change needed there.
- All legacy fields (`firstTimeUse`, `paymentReference`) are preserved for backwards compatibility.

## Test plan

- [ ] `mvn compile` passes with no errors (verified locally)
- [ ] `mvn test` passes for existing unit tests
- [ ] Verify new fields serialize correctly to JSON with a manual integration test using a `CREDENTIAL_ON_FILE` payment request

🤖 Generated with [Claude Code](https://claude.com/claude-code)