### PR TITLE
chore: bump version to 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0] - 2026-08-04
+
+### Added
+
+- **SDK ergonomics**: typed exceptions, configurable retry, and auto-pagination ([#392](https://github.com/mercadopago/sdk-java/pull/392))
+  - `MPApiException` now has 12 specific subtypes per HTTP status code (`400`→`MPBadRequestException`, `429`→`MPRateLimitException`, etc.)
+  - `MPRequestOptions` gains optional `maxRetries`, `retryOn`, `initialDelayMs`, `maxDelayMs` and `onRetry` callback
+  - New `MPAutoPagingIterable<T>` for lazy auto-pagination on `PaymentClient`, `CustomerClient` and `PreapprovalClient`
+- **Missing API methods** — `DisbursementRefundClient.list()`, `AdvancedPaymentClient.update()`, `CustomerCard.update()`, `PaymentClient.update()` ([#391](https://github.com/mercadopago/sdk-java/pull/391))
+- **CREDENTIAL_ON_FILE messaging fields** on `Payment` types ([#388](https://github.com/mercadopago/sdk-java/pull/388)): `firstTransaction`, `storage`, `transactionInitiator`, `reference`
+- **Example**: add create preference example ([#310](https://github.com/mercadopago/sdk-java/pull/310))
+
+### Fixed
+
+- Webhook `toleranceSeconds` unit mismatch — `ts` header value was being compared in seconds against a millisecond clock ([#393](https://github.com/mercadopago/sdk-java/pull/393))
+- `constantTimeEquals` `RangeError` on multibyte v1 hash ([#393](https://github.com/mercadopago/sdk-java/pull/393))
+
+### Dependencies
+
+- Bump `httpclient5` to `5.6.3` ([#389](https://github.com/mercadopago/sdk-java/pull/389))
+- Bump `actions/setup-java` to `v5.7.0` ([#390](https://github.com/mercadopago/sdk-java/pull/390))
+- Bump `actions/checkout` to `v7.0.1` ([#387](https://github.com/mercadopago/sdk-java/pull/387))
+
 ## [3.3.0] - 2026-06-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ already.
 <dependency>
   <groupId>com.mercadopago</groupId>
   <artifactId>sdk-java</artifactId>
-  <version>3.3.1</version>
+  <version>3.4.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.mercadopago</groupId>
     <artifactId>sdk-java</artifactId>
-    <version>3.3.1</version>
+    <version>3.4.0</version>
     <packaging>jar</packaging>
 
     <name>Mercadopago SDK</name>

--- a/src/main/java/com/mercadopago/MercadoPagoConfig.java
+++ b/src/main/java/com/mercadopago/MercadoPagoConfig.java
@@ -35,7 +35,7 @@ import org.apache.http.client.HttpRequestRetryHandler;
  */
 public class MercadoPagoConfig {
 
-  public static final String CURRENT_VERSION = "3.3.1";
+  public static final String CURRENT_VERSION = "3.4.0";
 
   /** Internal MercadoPago product identifier sent in every API request for analytics. */
   public static final String PRODUCT_ID = "BC32A7VTRPP001U8NHJ0";


### PR DESCRIPTION
## Summary

- Bump version from `3.3.1` to `3.4.0`
- Update `pom.xml`, `MercadoPagoConfig.java`, `README.md`, and `CHANGELOG.md`

## Changelog entry

### Added
- **SDK ergonomics**: typed exceptions, configurable retry, and auto-pagination ([#392](https://github.com/mercadopago/sdk-java/pull/392))
  - `MPApiException` now has 12 specific subtypes per HTTP status code
  - `MPRequestOptions` gains optional `maxRetries`, `retryOn`, `initialDelayMs`, `maxDelayMs` and `onRetry` callback
  - New `MPAutoPagingIterable<T>` for lazy auto-pagination on `PaymentClient`, `CustomerClient` and `PreapprovalClient`
- **Missing API methods** — `DisbursementRefundClient.list()`, `AdvancedPaymentClient.update()`, `CustomerCard.update()`, `PaymentClient.update()` ([#391](https://github.com/mercadopago/sdk-java/pull/391))
- **CREDENTIAL_ON_FILE messaging fields** on `Payment` types ([#388](https://github.com/mercadopago/sdk-java/pull/388)): `firstTransaction`, `storage`, `transactionInitiator`, `reference`
- **Example**: add create preference example ([#310](https://github.com/mercadopago/sdk-java/pull/310))

### Fixed
- Webhook `toleranceSeconds` unit mismatch ([#393](https://github.com/mercadopago/sdk-java/pull/393))
- `constantTimeEquals` `RangeError` on multibyte v1 hash ([#393](https://github.com/mercadopago/sdk-java/pull/393))

### Dependencies
- Bump `httpclient5` to `5.6.3` ([#389](https://github.com/mercadopago/sdk-java/pull/389))
- Bump `actions/setup-java` to `v5.7.0` ([#390](https://github.com/mercadopago/sdk-java/pull/390))
- Bump `actions/checkout` to `v7.0.1` ([#387](https://github.com/mercadopago/sdk-java/pull/387))

## Test plan
- [ ] CI passes
- [ ] Version string is correct in all files