### PR TITLE
feat: add COF network data support + bump version to 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.0] - 2026-08-25
+
+### Added
+- **COF network data support**: new fields on `PaymentNetworkDataRequest`/`PaymentNetworkData`, `PaymentPointOfInteractionRequest`/`PaymentPointOfInteraction`, and `OrderStoredCredential`
+
 ## [3.5.0] - 2026-08-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ already.
 <dependency>
   <groupId>com.mercadopago</groupId>
   <artifactId>sdk-java</artifactId>
-  <version>3.5.0</version>
+  <version>3.6.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.mercadopago</groupId>
     <artifactId>sdk-java</artifactId>
-    <version>3.5.0</version>
+    <version>3.6.0</version>
     <packaging>jar</packaging>
 
     <name>Mercadopago SDK</name>

--- a/src/main/java/com/mercadopago/MercadoPagoConfig.java
+++ b/src/main/java/com/mercadopago/MercadoPagoConfig.java
@@ -35,7 +35,7 @@ import org.apache.http.client.HttpRequestRetryHandler;
  */
 public class MercadoPagoConfig {
 
-  public static final String CURRENT_VERSION = "3.5.0";
+  public static final String CURRENT_VERSION = "3.6.0";
 
   /** Internal MercadoPago product identifier sent in every API request for analytics. */
   public static final String PRODUCT_ID = "BC32A7VTRPP001U8NHJ0";

--- a/src/main/java/com/mercadopago/client/payment/PaymentNetworkDataRequest.java
+++ b/src/main/java/com/mercadopago/client/payment/PaymentNetworkDataRequest.java
@@ -1,0 +1,11 @@
+package com.mercadopago.client.payment;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PaymentNetworkDataRequest {
+  private final String networkTransactionId;
+  private final String transactionLinkId;
+}

--- a/src/main/java/com/mercadopago/client/payment/PaymentPointOfInteractionRequest.java
+++ b/src/main/java/com/mercadopago/client/payment/PaymentPointOfInteractionRequest.java
@@ -23,4 +23,6 @@ public class PaymentPointOfInteractionRequest {
   /** Transaction data associated with the point of interaction. */
   private final PaymentTransactionDataRequest transactionData;
 
+  private final PaymentNetworkDataRequest networkData;
+
 }

--- a/src/main/java/com/mercadopago/resources/order/OrderStoredCredential.java
+++ b/src/main/java/com/mercadopago/resources/order/OrderStoredCredential.java
@@ -1,5 +1,6 @@
 package com.mercadopago.resources.order;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -25,4 +26,7 @@ public class OrderStoredCredential {
 
     /** Whether this is the first payment in a series using stored credentials. */
     private Boolean firstPayment;
+
+    @SerializedName("previous_transaction_reference")
+    private String previousTransactionReference;
 }

--- a/src/main/java/com/mercadopago/resources/payment/PaymentNetworkData.java
+++ b/src/main/java/com/mercadopago/resources/payment/PaymentNetworkData.java
@@ -1,0 +1,9 @@
+package com.mercadopago.resources.payment;
+
+import lombok.Getter;
+
+@Getter
+public class PaymentNetworkData {
+  private String networkTransactionId;
+  private String transactionLinkId;
+}

--- a/src/main/java/com/mercadopago/resources/payment/PaymentPointOfInteraction.java
+++ b/src/main/java/com/mercadopago/resources/payment/PaymentPointOfInteraction.java
@@ -27,4 +27,6 @@ public class PaymentPointOfInteraction {
 
   /** Transaction-level data from the interaction channel (e.g. QR code, ticket URL). */
   private PaymentTransactionData transactionData;
+
+  private PaymentNetworkData networkData;
 }


### PR DESCRIPTION
## Summary
- Add COF network data support: new fields on \`PaymentNetworkDataRequest\`/\`PaymentNetworkData\`, \`PaymentPointOfInteractionRequest\`/\`PaymentPointOfInteraction\`, and \`OrderStoredCredential\`
- Bump version from \`3.5.0\` to \`3.6.0\`
- Update \`pom.xml\`, \`MercadoPagoConfig.java\`, \`README.md\`, \`CHANGELOG.md\`

## Test plan
- [ ] CI passes
- [ ] Version string is correct in all files