### PR TITLE
feat: support legacy COF network transaction id

### DIFF
--- a/src/main/java/com/mercadopago/client/payment/PaymentTransactionDataRequest.java
+++ b/src/main/java/com/mercadopago/client/payment/PaymentTransactionDataRequest.java
@@ -23,6 +23,8 @@ public class PaymentTransactionDataRequest {
   private PaymentPaymentReferenceRequest paymentReference;
   /** Billing date for the current invoice period (e.g. "2023-01-15"). */
   private String billingDate;
+  /** Legacy card-network transaction identifier within transaction data. */
+  private String networkTransactionId;
   /**
    * Whether this is the first transaction for a CREDENTIAL_ON_FILE payment.
    * Replaces the legacy {@code firstTimeUse} field in new integrations.

--- a/src/main/java/com/mercadopago/resources/payment/PaymentTransactionData.java
+++ b/src/main/java/com/mercadopago/resources/payment/PaymentTransactionData.java
@@ -53,6 +53,9 @@ public class PaymentTransactionData {
   /** Billing date for subscription or recurring payment invoices. */
   private String billingDate;
 
+  /** Legacy card-network transaction identifier within transaction data. */
+  private String networkTransactionId;
+
   /**
    * Whether this is the first transaction for a CREDENTIAL_ON_FILE payment.
    * Replaces the legacy {@code firstTimeUse} field in new integrations.


### PR DESCRIPTION
## Summary
- Add support for legacy COF network transaction id on `PaymentTransactionDataRequest`/`PaymentTransactionData`
- Follow-up to #410 (COF network data support), which already merged into master

## Test plan
- [ ] CI passes