### PR TITLE
chore: bump version to 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.7.0] - 2026-08-27
+
+### Added
+- **Credential-on-file and automatic payments**: support nested `network_data`, expanded gateway network data, and `automatic_payments.subscription`.
+
 ## [3.6.0] - 2026-08-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ already.
 <dependency>
   <groupId>com.mercadopago</groupId>
   <artifactId>sdk-java</artifactId>
-  <version>3.6.0</version>
+  <version>3.7.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.mercadopago</groupId>
     <artifactId>sdk-java</artifactId>
-    <version>3.6.0</version>
+    <version>3.7.0</version>
     <packaging>jar</packaging>
 
     <name>Mercadopago SDK</name>

--- a/src/main/java/com/mercadopago/MercadoPagoConfig.java
+++ b/src/main/java/com/mercadopago/MercadoPagoConfig.java
@@ -35,7 +35,7 @@ import org.apache.http.client.HttpRequestRetryHandler;
  */
 public class MercadoPagoConfig {
 
-  public static final String CURRENT_VERSION = "3.6.0";
+  public static final String CURRENT_VERSION = "3.7.0";
 
   /** Internal MercadoPago product identifier sent in every API request for analytics. */
   public static final String PRODUCT_ID = "BC32A7VTRPP001U8NHJ0";


### PR DESCRIPTION
## Summary

Bumps the Java SDK release version to 3.7.0 after the latest merged backwards-compatible functionality.

## Files updated

- pom.xml
- src/main/java/com/mercadopago/MercadoPagoConfig.java
- README.md
- CHANGELOG.md

## Validation

- Confirmed version metadata and changelog consistency.
- No runtime code changes.